### PR TITLE
Fix CI by silencing warning

### DIFF
--- a/asub
+++ b/asub
@@ -11,7 +11,7 @@ use Sys::Hostname qw/hostname/;
 my $version = "2.2";
 
 # parsing command line
-my %opts = (R=>'', j=>'', q=>'', c=>'', w=>'', M=>'', G=>'', n=>1, m=>'', W=>'', C=>'', g=>1, pe=>'smp');
+my %opts = (R=>'', j=>'', q=>'', c=>'', w=>'', M=>'', G=>'', n=>1, m=>'', W=>'', C=>'', g=>1, pe=>'smp', P => '');
 getopts('P:R:j:k:q:c:pw:pe:M:n:m:W:g:C:Gx:', \%opts);
 &usage if (-t STDIN && @ARGV == 0);
 


### PR DESCRIPTION
    Use of uninitialized value in concatenation (.) or string at ...